### PR TITLE
 Add Basic CRUD Endpoints for Products

### DIFF
--- a/week_3/data/products.csv
+++ b/week_3/data/products.csv
@@ -6,4 +6,4 @@ product_id,product_name,quantity,price,type,expiry_date,warranty_period,author,p
 205,Pineapple,7,-2.5,food,2025-10-01,,,
 206,Smartphone,3,70000,electronic,,18,,
 207,Data Science,8,450,book,,,Alice,250
-208,Desk,10,3000,,,,
+208,Desk,10,3000,,,,,


### PR DESCRIPTION
### Description:

- Implemented **POST** /products endpoint to create a new product with Pydantic validation.
- Implemented **PUT** /products/<product_id> endpoint to update existing product details.
- Added **DELETE** /products/<product_id> endpoint that removes a product and returns 204 No Content.

These changes complete the basic Create, Update, and Delete functionality for the products API.

Screen Shot of each API Endpoint is listed below - 
**POST:**
<img width="1920" height="1080" alt="Week_5_4" src="https://github.com/user-attachments/assets/e7a3d26e-c0f0-43b3-907f-117a6a7f176c" />

**PUT:**
<img width="1920" height="1080" alt="Week_5_4_1" src="https://github.com/user-attachments/assets/d5942176-1148-4c7e-8126-b0ebbfcf4a39" />

**DELETE:**
<img width="1920" height="1080" alt="Week_5_4_2" src="https://github.com/user-attachments/assets/c1ffefb4-d614-428d-8be7-46c5e6e1de1c" />
