### PR TITLE
Add RAG-powered /chat/inventory endpoint

### DIFF
--- a/week_8/api/app.py
+++ b/week_8/api/app.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 
 from .db import db, migrate
 from .routes import api_bp, auth_bp
+from .routes.chat import chat_bp 
 from .config import get_config
 from .seed import seed_db
 
@@ -64,6 +65,7 @@ def create_app(config: Optional[Dict[str, Any]] = None) -> Flask:
     # register blueprints
     app.register_blueprint(api_bp)
     app.register_blueprint(auth_bp)
+    app.register_blueprint(chat_bp)  
 
     # CLI command seed-db
     app.cli.add_command(seed_db)

--- a/week_8/api/routes/chat.py
+++ b/week_8/api/routes/chat.py
@@ -1,0 +1,41 @@
+"""Chat-related API routes for RAG-based Q&A."""
+
+from flask import Blueprint, request, jsonify
+from ..utils.security import jwt_required
+from week_8.scripts.rag_bot import load_vector_store, build_rag_chain
+
+chat_bp = Blueprint("chat", __name__, url_prefix="/chat")
+
+# Load RAG chain once at startup (avoid rebuilding on every request)
+_vector_store = load_vector_store()
+_rag_chain = build_rag_chain(_vector_store)
+
+
+@chat_bp.route("/inventory", methods=["POST"])
+@jwt_required
+def chat_inventory():
+    """Answer inventory-related questions using RAG.
+
+    Expected JSON body:
+        {
+            "question": "<str>"
+        }
+
+    Returns:
+        {
+            "answer": "<str>"
+        }
+    """
+    data = request.get_json(force=True, silent=True)
+    if not data or "question" not in data:
+        return jsonify({"error": "Missing 'question' in request body"}), 400
+
+    question: str = data["question"].strip()
+    if not question:
+        return jsonify({"error": "Question cannot be empty"}), 400
+
+    try:
+        answer: str = _rag_chain.invoke(question)
+        return jsonify({"answer": answer}), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
**Description**

This PR introduces a new chat endpoint for inventory-related Q&A powered by the existing RAG pipeline.

**Changes Made**

- Added new chat.py blueprint under week_8/api/routes/.
- Implemented POST /chat/inventory endpoint:
- Accepts JSON input with a question.
- Uses RAG chain (rag_bot) to generate context-aware answers.
- Returns response as JSON.
- Updated app.py to register the new chat_bp.

**Testing**

- Verified endpoint locally with curl and Postman using JWT auth.
- Example request:

```
  POST http://127.0.0.1:5000/chat/inventory \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"question": "What is the price of Macbook?"}'
```

- Received expected JSON answers from RAG.

**Notes**

- Endpoint is JWT-protected.
- Vector store and chain are loaded once at startup for efficiency.

**Below is the output of endpoint:**
<img width="1457" height="967" alt="week_8_5_1" src="https://github.com/user-attachments/assets/78729718-ebd4-410e-8c1f-88e05b54e1eb" />

<img width="1457" height="967" alt="week_8_5_2" src="https://github.com/user-attachments/assets/ce173138-d793-4f82-92a0-e3d3eb683bf4" />
